### PR TITLE
Fixed google link on footer of the website

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -83,7 +83,7 @@ module.exports = {
           items: [
             {
               label: "Google",
-              to: "/google",
+              to: "https://www.google.com/",
             },
             {
               label: "GitHub",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -94,7 +94,7 @@ module.exports = {
       ],
       copyright: `Copyright © ${new Date().getFullYear()} PEcAn Project.`,
     },
-    hideableSidebar: true,
+    //hideableSidebar: true,
   },
   presets: [
     [


### PR DESCRIPTION
Given link gor the google on the footer of the webpage is broken, docusaurus.config.js file is updated regarding this.